### PR TITLE
apex: Don't ship wifi

### DIFF
--- a/apex/Android.bp
+++ b/apex/Android.bp
@@ -151,12 +151,3 @@ prebuilt_apex {
     owner: "google",
     prefer: true,
 }
-
-// Google com.google.android.wifi
-prebuilt_apex {
-    name: "com.google.android.wifi",
-    src: "com.google.android.wifi.apex",
-    overrides: ["com.android.wifi"],
-    owner: "google",
-    prefer: true,
-}

--- a/config/apex.mk
+++ b/config/apex.mk
@@ -38,5 +38,4 @@ PRODUCT_PACKAGES += \
 	com.google.android.resolv \
 	com.google.android.sdkext \
 	com.google.android.telephony \
-	com.google.android.tzdata2 \
-	com.google.android.wifi
+	com.google.android.tzdata2

--- a/config/rro_overlays.mk
+++ b/config/rro_overlays.mk
@@ -16,6 +16,7 @@
 
 # Overlays
 PRODUCT_PACKAGES += \
+    AccentColorBlueOverlay \
     FontArbutusSourceOverlay \
     FontArvoLatoOverlay \
     FontGoogleSansOverlayOverlay \

--- a/rro_overlays/Accents/AccentColorBlueOverlay/Android.bp
+++ b/rro_overlays/Accents/AccentColorBlueOverlay/Android.bp
@@ -1,0 +1,23 @@
+//
+// Copyright (C) 2020 Raphielscape LLC. and Haruka LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+runtime_resource_overlay {
+    name: "AccentColorBlueOverlay",
+    theme: "AccentColorBlue",
+    certificate: "platform",
+    sdk_version: "current",
+    product_specific: true
+}

--- a/rro_overlays/Accents/AccentColorBlueOverlay/AndroidManifest.xml
+++ b/rro_overlays/Accents/AccentColorBlueOverlay/AndroidManifest.xml
@@ -1,0 +1,25 @@
+<!--
+/**
+ * Copyright (c) 2018, The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.android.theme.color.blue"
+          android:versionCode="1"
+          android:versionName="1.0">
+    <overlay android:targetPackage="android" android:category="android.theme.customization.accent_color" android:priority="1"/>
+
+    <application android:label="@string/accent_color_blue_overlay" android:hasCode="false"/>
+</manifest>

--- a/rro_overlays/Accents/AccentColorBlueOverlay/res/values/colors_device_defaults.xml
+++ b/rro_overlays/Accents/AccentColorBlueOverlay/res/values/colors_device_defaults.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) 2018, The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources>
+    <color name="accent_device_default_dark">#ff8ab4f8</color>
+    <color name="accent_device_default_light">#ff1a73e8</color>
+</resources>

--- a/rro_overlays/Accents/AccentColorBlueOverlay/res/values/strings.xml
+++ b/rro_overlays/Accents/AccentColorBlueOverlay/res/values/strings.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/**
+ * Copyright (c) 2018, The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Blue accent color name application label. [CHAR LIMIT=50] -->
+    <string name="accent_color_blue_overlay" translatable="false">Blue</string>
+</resources>
+


### PR DESCRIPTION
This commit fixes the hotspot issue in some devices having updateable apex support (eg. raphael) due to some weird unknown reason. So removing the apex wifi fixes the hotspot issue. 

Bug - Could not turn on Hotspot (switch turns off itself in a sec).
Test - applied and hotspot works fine now.
Tested device - raphael
Test Signed off - Raaj52