### PR TITLE
derp: tools: fixup datetime

### DIFF
--- a/tools/generate_json_build_info.sh
+++ b/tools/generate_json_build_info.sh
@@ -11,7 +11,8 @@ if [ "$1" ]; then
         if [[ $file_name == *"Official"* ]]; then # only generate for official builds
             file_size=$(stat -c%s $file_path)
             md5=$(cat "$file_path.md5sum" | cut -d' ' -f1)
-            datetime=$(date +%s)
+            currenttime=$(date +%s)
+            datetime=$(($currenttime - 86400))
             id=$(sha256sum $file_path | awk '{ print $1 }')
             link="https://sourceforge.net/projects/derpfest/files/${device_name}/${file_name}/download"
             echo "{" > $file_path.json


### PR DESCRIPTION
The datetime value before was a little extra to the actual datetime
value in props so updater showed updates even if the latest build was flashed
To fixup,reducing the datetime value by 1 day so that it will cancel out the difference between prop and datetime in json