### PR TITLE
fixup! overlay: SystemUI: Offload WM shell to another thread

### DIFF
--- a/overlay/common/frameworks/base/libs/WindowManager/Shell/res/values/config.xml
+++ b/overlay/common/frameworks/base/libs/WindowManager/Shell/res/values/config.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2020 The Android Open Source Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<resources>
+
+    <!-- Determines whether the shell features all run on another thread. This is to be overrided
+         by the resources of the app using the Shell library. -->
+    <bool name="config_enableShellMainThread">true</bool>
+</resources>

--- a/overlay/common/frameworks/base/packages/SystemUI/res/values/config.xml
+++ b/overlay/common/frameworks/base/packages/SystemUI/res/values/config.xml
@@ -27,9 +27,6 @@
         <item>com.android.systemui.plugin.globalactions.wallet</item>
     </string-array>
 
-    <!-- Determines whether the shell features all run on another thread. -->
-    <bool name="config_enableShellMainThread">true</bool>
-
     <!-- Screenshot editing default activity.  Must handle ACTION_EDIT image/png intents.
          Blank sends the user to the Chooser first.
          This name is in the ComponentName flattened format (package/class)  -->


### PR DESCRIPTION
Fixes: 69fb2812d766728eabddf6ac101d2dffce458614 this config moved location

Additional note: this is default enabled on Pixels and many other configurations. It is generally a sane default, with no known google shipped configurations disabling it.