### PR TITLE
overlay: Treat com.derp.device.DeviceSettings as privileged

### DIFF
--- a/overlay/common/frameworks/base/packages/SystemUI/res/values/config.xml
+++ b/overlay/common/frameworks/base/packages/SystemUI/res/values/config.xml
@@ -22,6 +22,7 @@
     <string-array name="config_pluginAllowlist" translatable="false">
         <item>com.android.systemui</item>
         <item>com.android.systemui.plugin.globalactions.wallet</item>
+        <item>com.derp.device.DeviceSettings</item>
         <item>org.lineageos.settings.device</item>
         <item>com.android.systemui.clocks.bignum</item>
         <item>com.android.systemui.clocks.calligraphy</item>


### PR DESCRIPTION
This marks our very generic package as allowed to provide privileged SystemUI plugins.

Change-Id: Icb68d9a535d275cb2c808174eb123b69308c1fed