### PR TITLE
config: add pixel-framework inclusion in common_full_tablet_wifionly.mk, fixing settings crash

### DIFF
--- a/config/common_full_tablet_wifionly.mk
+++ b/config/common_full_tablet_wifionly.mk
@@ -15,4 +15,7 @@ PRODUCT_PACKAGES += \
 # Include DerpFest LatinIME dictionaries
 PRODUCT_PACKAGE_OVERLAYS += vendor/derp/overlay/dictionaries
 
+# Pixel Framework
+$(call inherit-product, vendor/pixel-framework/config.mk)
+
 $(call inherit-product, vendor/derp/config/wifionly.mk)


### PR DESCRIPTION
the inclusion of pixel framework might be missing in other configs as well, causing settings crash in other configurations.  @NurKeinNeid 