### PR TITLE
DeviceConfig: Set Google photos as cloud picker provider

### DIFF
--- a/overlay/common/packages/apps/SimpleDeviceConfig/res/values/config.xml
+++ b/overlay/common/packages/apps/SimpleDeviceConfig/res/values/config.xml
@@ -42,6 +42,10 @@
         <!-- Globally enable the new photo picker -->
         <item>storage_native_boot/take_over_get_content=true</item>
 
+        <!-- Media Provider -->
+        <item>mediaprovider/cloud_media_feature_enabled=true</item>
+        <item>mediaprovider/allowed_cloud_providers=com.google.android.apps.photos.cloudpicker</item>
+
         <!-- Enable smart actions in the clipboard overlay -->
         <item>systemui/clipboard_overlay_show_actions=true</item>
 

--- a/overlay/common/packages/apps/SimpleDeviceConfig/res/values/config.xml
+++ b/overlay/common/packages/apps/SimpleDeviceConfig/res/values/config.xml
@@ -287,9 +287,6 @@
         <!-- Notifications -->
         <item>notification_assistant/generate_actions=true</item>
         <item>notification_assistant/generate_replies=true</item>
-
-        <!-- Globally enable the new photo picker -->
-        <item>storage_native_boot/take_over_get_content=true</item>
     </string-array>
 
     <string-array name="configs_base_soft">


### PR DESCRIPTION
* allowlist is now enforced

[1] https://github.com/PixysOS-Beta/packages_providers_MediaProvider/commit/fbcd419dc02658adb35a5355cc4fd1e5a7f6b72f