### PR TITLE
config: TARGET_NOT_USES_BLUR now actually behaves as intended

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -138,13 +138,20 @@ PRODUCT_ARTIFACT_PATH_REQUIREMENT_ALLOWED_LIST += \
 endif
 
 # Blur
-PRODUCT_PRODUCT_PROPERTIES += \
-    ro.sf.blurs_are_expensive=1 \
-    ro.surface_flinger.supports_background_blur=1
-ifeq ($(TARGET_NOT_USES_BLUR),true)
-PRODUCT_PRODUCT_PROPERTIES += \
-    persist.sysui.disableBlur=1
+ifndef TARGET_NOT_USES_BLUR
+    USES_BLUR=1
 endif
+
+ifeq ($(TARGET_NOT_USES_BLUR),true)
+    USES_BLUR=0
+else
+    USES_BLUR=1
+endif
+
+PRODUCT_PRODUCT_PROPERTIES += \
+    ro.sf.blurs_are_expensive=$(USES_BLUR) \
+    ro.surface_flinger.supports_background_blur=$(USES_BLUR) \
+    persist.sysui.disableBlur=$(1 - USES_BLUR)
 
 # BtHelper
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
config: TARGET_NOT_USES_BLUR now actually behaves as intended: if to true, blurs are disabled and the toggle is gone from settings; if set to anything other than true, the switch is still present in settings; if not set at all, blurs are enabled and the switch is present in settings.