### PR TITLE
fixup! config: TARGET_NOT_USES_BLUR

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -143,6 +143,7 @@ PRODUCT_ARTIFACT_PATH_REQUIREMENT_ALLOWED_LIST += \
     system/bin/procmem
 endif
 
+
 # Blur
 ifndef TARGET_NOT_USES_BLUR
     USES_BLUR=1
@@ -154,10 +155,16 @@ else
     USES_BLUR=1
 endif
 
+ifeq ($(USES_BLUR),1)
+    DISABLE_BLUR=0
+else
+    DISABLE_BLUR=1
+endif
+
 PRODUCT_PRODUCT_PROPERTIES += \
     ro.sf.blurs_are_expensive=$(USES_BLUR) \
     ro.surface_flinger.supports_background_blur=$(USES_BLUR) \
-    persist.sysui.disableBlur=$(1 - USES_BLUR)
+    persist.sysui.disableBlur=$(DISABLE_BLUR)
 
 # BtHelper
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
Now persist.sysui.disableBlur=1 , if we set TARGET_NOT_USES_BLUR=1 which is the correct implementation.
Since after this 552edec , it sets a null value for persist.sysui.disableBlur at build.prop instead of "1" , if we use disable blur flag .