### PR TITLE
fixup! config: TARGET_NOT_USES_BLUR now actually behaves as intended:…

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -158,7 +158,7 @@ endif
 PRODUCT_PRODUCT_PROPERTIES += \
     ro.sf.blurs_are_expensive=$(USES_BLUR) \
     ro.surface_flinger.supports_background_blur=$(USES_BLUR) \
-    persist.sysui.disableBlur=$(1 - USES_BLUR)
+    persist.sysui.disableBlur=$(shell echo $$((1 - $(USES_BLUR))))
 
 # BtHelper
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
… if set to true, blurs are disabled and the toggle is gone from settings; if set to anything other than true, the switch is still present in settings; if not set at all, blurs are enabled and the switch is present in settings.