### PR TITLE
kernel: Allow to override toolchain prefix used for vDSO32 building

### DIFF
--- a/config/BoardConfigKernel.mk
+++ b/config/BoardConfigKernel.mk
@@ -25,6 +25,8 @@
 #                                          defaults to arm-linux-androidkernel- for arm
 #                                                      aarch64-linux-android- for arm64
 #                                                      x86_64-linux-android- for x86
+#   TARGET_KERNEL_CROSS_COMPILE_PREFIX_ARM32 = Compiler prefix for building vDSO32
+#                                              defaults to arm-linux-androidkernel- for arm64
 #
 #   TARGET_KERNEL_CLANG_COMPILE        = Compile kernel with clang, defaults to true
 #   TARGET_KERNEL_CLANG_VERSION        = Clang prebuilts version, optional, defaults to clang-stable
@@ -132,10 +134,24 @@ ifneq ($(KERNEL_NO_GCC), true)
         KERNEL_TOOLCHAIN_PREFIX ?= $(KERNEL_TOOLCHAIN_PREFIX_$(KERNEL_ARCH))
     endif
 
+    TARGET_KERNEL_CROSS_COMPILE_PREFIX_ARM32 := $(strip $(TARGET_KERNEL_CROSS_COMPILE_PREFIX_ARM32))
+    ifneq ($(TARGET_KERNEL_CROSS_COMPILE_PREFIX_ARM32),)
+        KERNEL_TOOLCHAIN_PREFIX_ARM32 ?= $(TARGET_KERNEL_CROSS_COMPILE_PREFIX_ARM32)
+    else
+        KERNEL_TOOLCHAIN_ARM32 ?= $(KERNEL_TOOLCHAIN_arm)
+        KERNEL_TOOLCHAIN_PREFIX_ARM32 ?= $(KERNEL_TOOLCHAIN_PREFIX_arm)
+    endif
+
     ifeq ($(KERNEL_TOOLCHAIN),)
         KERNEL_TOOLCHAIN_PATH := $(KERNEL_TOOLCHAIN_PREFIX)
     else
         KERNEL_TOOLCHAIN_PATH := $(KERNEL_TOOLCHAIN)/$(KERNEL_TOOLCHAIN_PREFIX)
+    endif
+
+    ifeq ($(KERNEL_TOOLCHAIN_ARM32),)
+        KERNEL_TOOLCHAIN_PATH_ARM32 := $(KERNEL_TOOLCHAIN_PREFIX_ARM32)
+    else
+        KERNEL_TOOLCHAIN_PATH_ARM32 := $(KERNEL_TOOLCHAIN_ARM32)/$(KERNEL_TOOLCHAIN_PREFIX_ARM32)
     endif
 
     # We need to add GCC toolchain to the path no matter what
@@ -150,8 +166,8 @@ ifneq ($(KERNEL_NO_GCC), true)
 
     # Needed for CONFIG_COMPAT_VDSO, safe to set for all arm64 builds
     ifeq ($(KERNEL_ARCH),arm64)
-        KERNEL_CROSS_COMPILE += CROSS_COMPILE_ARM32="$(KERNEL_TOOLCHAIN_arm)/$(KERNEL_TOOLCHAIN_PREFIX_arm)"
-        KERNEL_CROSS_COMPILE += CROSS_COMPILE_COMPAT="$(KERNEL_TOOLCHAIN_arm)/$(KERNEL_TOOLCHAIN_PREFIX_arm)"
+        KERNEL_CROSS_COMPILE += CROSS_COMPILE_ARM32="$(KERNEL_TOOLCHAIN_PATH_ARM32)"
+        KERNEL_CROSS_COMPILE += CROSS_COMPILE_COMPAT="$(KERNEL_TOOLCHAIN_PATH_ARM32)"
     endif
 
     ifeq ($(TARGET_KERNEL_CLANG_COMPILE),false)


### PR DESCRIPTION
We can override prefix used for normal kernel building with TARGET_KERNEL_CROSS_COMPILE_PREFIX variable but we can't do the same for vDSO32. Let's correct this injustice by introducing TARGET_KERNEL_CROSS_COMPILE_PREFIX_ARM32 variable.

Change-Id: I8029488d957c8314a0ab788f4627e960848974c1